### PR TITLE
Mirrors now use a singleton to reference the main camera to make changing the camera and instancing mirrors easier

### DIFF
--- a/Demo/DemoWorld.tscn
+++ b/Demo/DemoWorld.tscn
@@ -61,13 +61,11 @@ skeleton = NodePath("../../..")
 [node name="Mirror" type="Node3D" parent="."]
 script = ExtResource("2")
 ResolutionPerUnit = 200
-MainCamPath = NodePath("../Player/CameraRod/MainCamera")
 MirrorColor = Color(1, 1, 1, 1)
 
 [node name="Mirror2" type="Node3D" parent="."]
 transform = Transform3D(0.658492, 0, -0.752587, 0, 1, 0, 0.752587, 0, 0.658492, 2.4934, 0, 0.705538)
 script = ExtResource("2")
 ResolutionPerUnit = 200
-MainCamPath = NodePath("../Player/CameraRod/MainCamera")
 MirrorDistortion = 20
 DistortionTexture = SubResource("9")

--- a/Demo/DemoWorld.tscn
+++ b/Demo/DemoWorld.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://0576fim4xnjw"]
+[gd_scene load_steps=11 format=3 uid="uid://0576fim4xnjw"]
 
 [ext_resource type="Script" path="res://Demo/MainCamera.gd" id="1"]
 [ext_resource type="Script" path="res://addons/Mirror/Mirror/Mirror.gd" id="2"]
+[ext_resource type="Script" path="res://Demo/FPSLabel.gd" id="2_trh2v"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_omm3q"]
 
@@ -58,14 +59,23 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.4, 0)
 mesh = SubResource("7")
 skeleton = NodePath("../../..")
 
+[node name="FPS Label" type="Label" parent="Player/CameraRod"]
+offset_right = 40.0
+offset_bottom = 23.0
+script = ExtResource("2_trh2v")
+
 [node name="Mirror" type="Node3D" parent="."]
 script = ExtResource("2")
-ResolutionPerUnit = 200
 MirrorColor = Color(1, 1, 1, 1)
 
 [node name="Mirror2" type="Node3D" parent="."]
 transform = Transform3D(0.658492, 0, -0.752587, 0, 1, 0, 0.752587, 0, 0.658492, 2.4934, 0, 0.705538)
 script = ExtResource("2")
-ResolutionPerUnit = 200
 MirrorDistortion = 20
 DistortionTexture = SubResource("9")
+
+[node name="Mirror3" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.74169, 0)
+script = ExtResource("2")
+
+[node name="Rotation Tests" type="Node3D" parent="."]

--- a/Demo/FPSLabel.gd
+++ b/Demo/FPSLabel.gd
@@ -1,0 +1,5 @@
+extends Label
+
+
+func _process(_delta):
+	text = "FPS: " + str(Engine.get_frames_per_second())

--- a/Demo/MainCamera.gd
+++ b/Demo/MainCamera.gd
@@ -34,6 +34,7 @@ var speed = 0.1
 
 func _ready() -> void:
 	self.is_cursor_visible = false
+	#Since we know this will be the main camera, we must assign it as the main camera on startup
 	MirrorManager.main_camera = camera
 
 

--- a/Demo/MainCamera.gd
+++ b/Demo/MainCamera.gd
@@ -38,7 +38,7 @@ func _ready() -> void:
 	MirrorManager.main_camera = camera
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	process_basic_input()
 	
 	if Input.is_action_pressed("ui_up"):

--- a/Demo/MainCamera.gd
+++ b/Demo/MainCamera.gd
@@ -34,6 +34,7 @@ var speed = 0.1
 
 func _ready() -> void:
 	self.is_cursor_visible = false
+	MirrorManager.main_camera = camera
 
 
 func _process(delta: float) -> void:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Mirror properties that can be adjusted:
 
  After the addon is enabled a custom node is added to godot under the spatial node. 
 
- The main camera that renders the scene needs to be selected in the variables of the node. Only one camera is supported at a time. The plugin adds a secondary camera to the opposite side of the mirror relative to this camera and renders the image to the mirror surface.
+ Only one camera is supported at a time. At runtime, assign your main camera to the `MirrorManager.main_camera` variable. The plugin adds a secondary camera to the opposite side of the mirror relative to this camera and renders the image to the mirror surface.
 
  The cull mask array contains the visual layers which are NOT rendered. The render layers numbering is different from their indexing. To avoid rendering layer 1 add a 0 element to the list.
  To avoid rendering layer 2 add a 1 element to the list and so on.

--- a/addons/Mirror/Mirror/Mirror.gd
+++ b/addons/Mirror/Mirror/Mirror.gd
@@ -9,9 +9,6 @@ const whitegreen : Color = Color(0.9, 0.97, 0.94)
 ## Resolution of the rendered viewport is Size*ResolutionPerUnit
 @export var ResolutionPerUnit = 100
 
-## The NodePath to the main camera
-@export var MainCamPath: NodePath = ""
-
 ## The cull mask array contains the visual layers which are NOT rendered. The render layers numbering is different from their indexing. To avoid rendering layer 1 add a 0 element to the list. To avoid rendering layer 2 add a 1 element to the list and so on.
 @export var cullMask : Array[int] = []
 
@@ -24,7 +21,6 @@ const whitegreen : Color = Color(0.9, 0.97, 0.94)
 ## The distortion texture of the mirror
 @export var DistortionTexture: Texture2D
 
-var MainCam : Camera3D = null
 var cam : Camera3D
 var mirror : MeshInstance3D
 var viewport : SubViewport
@@ -36,7 +32,6 @@ func _enter_tree():
 
 
 func _ready():
-	MainCam = get_node_or_null(MainCamPath)
 	cam = $MirrorContainer/SubViewport/Camera3D
 	mirror = $MirrorContainer/MeshInstance3D
 	viewport = $MirrorContainer/SubViewport
@@ -44,7 +39,9 @@ func _ready():
 
 func _process(delta):
 	_ready() # need to reload for proper operation when used as a toolscript
-	if MainCam == null:
+	if Engine.is_editor_hint():
+		return
+	elif MirrorManager.main_camera == null:
 		# No camera specified for the mirror to operate checked
 		return
 	
@@ -69,11 +66,11 @@ func _process(delta):
 	# Transform3D the mirror camera to the opposite side of the mirror plane
 	var MirrorNormal = mirror.global_transform.basis.z	
 	var MirrorTransform =  Mirror_transform(MirrorNormal, mirror.global_transform.origin)
-	cam.global_transform = MirrorTransform * MainCam.global_transform
+	cam.global_transform = MirrorTransform * MirrorManager.main_camera.global_transform
 	
 	# Look perpendicular into the mirror plane for frostum camera
 	cam.global_transform = cam.global_transform.looking_at(
-			cam.global_transform.origin/2 + MainCam.global_transform.origin/2, \
+			cam.global_transform.origin/2 + MirrorManager.main_camera.global_transform.origin/2, \
 			mirror.global_transform.basis.y
 		)
 	var cam2mirror_offset = mirror.global_transform.origin - cam.global_transform.origin

--- a/addons/Mirror/Mirror/Mirror.gd
+++ b/addons/Mirror/Mirror/Mirror.gd
@@ -39,7 +39,8 @@ func _ready():
 
 func _process(delta):
 	_ready() # need to reload for proper operation when used as a toolscript
-	if Engine.is_editor_hint():
+	
+	if Engine.is_editor_hint(): # stops from running in the editor to avoid failed calculations
 		return
 	elif MirrorManager.main_camera == null:
 		# No camera specified for the mirror to operate checked

--- a/addons/Mirror/MirrorManager.gd
+++ b/addons/Mirror/MirrorManager.gd
@@ -1,3 +1,4 @@
 extends Node
 
+
 var main_camera : Camera3D

--- a/addons/Mirror/MirrorManager.gd
+++ b/addons/Mirror/MirrorManager.gd
@@ -1,4 +1,6 @@
 extends Node
 
-
+## Stores the current camera for all mirrors
 var main_camera : Camera3D
+
+var resolution : int = 2048

--- a/addons/Mirror/MirrorManager.gd
+++ b/addons/Mirror/MirrorManager.gd
@@ -1,0 +1,3 @@
+extends Node
+
+var main_camera : Camera3D

--- a/addons/Mirror/plugin.gd
+++ b/addons/Mirror/plugin.gd
@@ -4,9 +4,9 @@ extends EditorPlugin
 
 func _enter_tree():
 	add_custom_type("Mirror", "Node3D", preload("Mirror/Mirror.gd"), preload("icon.svg"))
-	pass
+	add_autoload_singleton("MirrorManager","res://addons/Mirror/MirrorManager.gd")
 
 
 func _exit_tree():
 	remove_custom_type("Mirror")
-	pass
+	remove_autoload_singleton("MirrorManager")

--- a/project.godot
+++ b/project.godot
@@ -60,4 +60,5 @@ common/enable_pause_aware_picking=true
 
 [rendering]
 
+renderer/rendering_method="gl_compatibility"
 environment/default_environment="res://Demo/default_env.tres"

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ config/description="A mirror resource and demo scene for a versatile mirror."
 run/main_scene="res://Demo/DemoWorld.tscn"
 config/features=PackedStringArray("4.0")
 
+[autoload]
+
+MirrorManager="*res://addons/Mirror/MirrorManager.gd"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/Mirror/plugin.cfg")


### PR DESCRIPTION
It felt a little inefficient to have to manually assign the main camera to every individual mirror. I found out you can dynamically add and remove autoload/singletons in plugin startup ([link](https://docs.godotengine.org/en/stable/classes/class_editorplugin.html#class-editorplugin-method-add-autoload-singleton)) and so I gave it a shot.

Weirdly, Godot seems to fail to detect the plugin's singleton in the editor, but the mirror still appears to work perfectly in the game. This does seem to be a [known issue](https://github.com/godotengine/godot/issues/30064) though. I made a small one if-statement workaround, no idea if I'm missing something here.

Let me know if you have any suggestions.